### PR TITLE
Enable bootstrap without AWS interface

### DIFF
--- a/polgen.py
+++ b/polgen.py
@@ -374,11 +374,6 @@ def init(args):
     if not repo_branch:
         repo_branch = "main"
     postfix = get_postfix(f"{repo_name}/{repo_branch}")
-    if not is_aws_interface_available():
-        print(
-            "We cannot interface with AWS. Either install and configure the AWS CLI or install Boto3."
-        )
-        sys.exit(1)
 
     if is_aws_interface_available():
         aws_account_id = get_aws_account_id()


### PR DESCRIPTION
When boto3 or the AWS CLI are not installed, we print manual instructions for the user. However, there was a check earlier in the bootstrap script that exited when no interface was found, never reaching the print statements.

This removes that early exit.